### PR TITLE
Allow known attributes with customized namespace prefix on xliff elements

### DIFF
--- a/Xliff.OM.Tests/Core/XliffElementTests.cs
+++ b/Xliff.OM.Tests/Core/XliffElementTests.cs
@@ -142,6 +142,19 @@
                 get { return (int)this.GetPropertyValue("Property"); }
                 set { this.SetPropertyValue(value, "Property"); }
             }
+
+            /// <summary>
+            /// Gets or sets a value that is used to verify attribute matching with namespaces
+            /// </summary>
+            [Converter(typeof(HexConverter))]
+            [DefaultValue(100)]
+            [SchemaEntity("ns1", "namespace1", "PropertyFromNamespace", Requirement.Optional)]
+            public int PropertyFromNamespace
+            {
+                get { return (int)this.GetPropertyValue("PropertyFromNamespace"); }
+                set { this.SetPropertyValue(value, "PropertyFromNamespace"); }
+            }
+
             #endregion Properties
 
             /// <summary>
@@ -830,6 +843,33 @@
             Assert.AreEqual("#/f=f1/g=g1/u=u1", span.SelectorPath, "SelectorPath is incorrect.");
         }
 
+        /// <summary>
+        /// Tests wether attribute value can be set regardless of differences in namespace prefix naming
+        /// </summary>
+        [TestMethod()]
+        [TestCategory(TestUtilities.UnitTestCategory)]
+        public void XliffElement_TrySetAttributeValue()
+        {
+            TestXliffElement element = new TestXliffElement();
+            const string propertyName = "PropertyFromNamespace";
+
+            Console.WriteLine("Test with default namespace prefix.");
+            var defaultNameInfo = new XmlNameInfo("ns1", "namespace1", "PropertyFromNamespace");
+            var result1 = ((IXliffDataConsumer) element).TrySetAttributeValue(defaultNameInfo, "A");
+            Assert.AreEqual(SetAttributeResult.Success, result1);
+            Assert.AreEqual(10, element.PropertyFromNamespace);
+
+            Console.WriteLine("Test with customized namespace prefix.");
+            var customizedXmlNameInfo = new XmlNameInfo("ns2", "namespace1", "PropertyFromNamespace");
+            var result2 = ((IXliffDataConsumer)element).TrySetAttributeValue(customizedXmlNameInfo, "B");
+            Assert.AreEqual(SetAttributeResult.Success, result2);
+            Assert.AreEqual(11, element.PropertyFromNamespace);
+
+            Console.WriteLine("Test with another namespace");
+            var anotherXmlNameInfo = new XmlNameInfo("ns3", "namespace3", "PropertyFromNamespace");
+            var result3 = ((IXliffDataConsumer)element).TrySetAttributeValue(anotherXmlNameInfo, "C");
+            Assert.AreEqual(SetAttributeResult.PossibleExtension, result3);
+        }
 
         #endregion Test Methods
     }

--- a/Xliff.OM.Tests/Serialization/TestData.cs
+++ b/Xliff.OM.Tests/Serialization/TestData.cs
@@ -14,6 +14,7 @@
         DocumentWithValidValues,
         DocumentWithExtensions,
         DocumentWithXmlPrefix,
+        DocumentWithTwoNamespaces,
         EmptyFile,
         FileNoteWithDefaultValues,
         FileNoteWithEmptyValues,
@@ -68,6 +69,7 @@
         UnitWithEmptyValues,
         UnitWithMetadata,
         UnitWithValidValues,
+        UnitWithAttributeHavingCustomNsPrefix,
         ValidDocument
     }
 }

--- a/Xliff.OM.Tests/Serialization/XliffReaderTests.cs
+++ b/Xliff.OM.Tests/Serialization/XliffReaderTests.cs
@@ -1,4 +1,7 @@
-﻿namespace Localization.Xliff.OM.Serialization.Tests
+﻿using System.Linq;
+using Localization.Xliff.OM.Extensibility;
+
+namespace Localization.Xliff.OM.Serialization.Tests
 {
     using System;
     using System.Collections.Generic;
@@ -171,6 +174,24 @@
             Assert.AreEqual(1, segment.Source.Text.Count, "Source text count is incorrect.");
             Assert.IsInstanceOfType(segment.Source.Text[0], typeof(PlainText), "Text[0] type is incorrect.");
             Assert.AreEqual("text", ((PlainText)segment.Source.Text[0]).Text, "Text[0].Text is incorrect.");
+        }
+
+        /// <summary>
+        /// Tests a document can have attributes from different namespaces on the same element.
+        /// </summary>
+        [TestMethod()]
+        [TestCategory(TestUtilities.UnitTestCategory)]
+        public void XliffReader_DocumentWithTwoNamespaces()
+        {
+            Deserialize(TestData.DocumentWithTwoNamespaces);
+
+            Assert.AreEqual("2.0", _document.Version);
+
+            var itsVersionAttribute = ((IExtensible) _document).Extensions.Single().GetAttributes().Single();
+            Assert.AreEqual("version", itsVersionAttribute.LocalName);
+            Assert.AreEqual("its", itsVersionAttribute.Prefix);
+            Assert.AreEqual("http://www.w3.org/2005/11/its", itsVersionAttribute.Namespace);
+            Assert.AreEqual("3.0", itsVersionAttribute.Value);
         }
 
         /// <summary>
@@ -1020,6 +1041,13 @@
                             "TargetDirectionality is incorrect.");
             Assert.IsTrue(unit.Translate, "Translate is incorrect.");
             Assert.AreEqual("type", unit.Type, "Type is incorrect.");
+
+            Console.WriteLine("Test for attribute with custom namespace prefix");
+            this.Deserialize(TestData.UnitWithAttributeHavingCustomNsPrefix);
+            unit = this._document.Files[0].Containers[0] as Unit;
+            Assert.IsNotNull(unit, "Unit is null.");
+            Assert.AreEqual(String.Empty, unit.Id, "Id is incorrect.");
+            Assert.AreEqual("100", unit.StorageRestriction, "StorageRestriction is incorrect");
         }
 
         /// <summary>

--- a/Xliff.OM.Tests/TestData.Xliff.OM.Tests/DocumentWithTwoNamespaces.xlf
+++ b/Xliff.OM.Tests/TestData.Xliff.OM.Tests/DocumentWithTwoNamespaces.xlf
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff xmlns="urn:oasis:names:tc:xliff:document:2.0" version="2.0" srcLang="en-US" trgLang="fr-FR" xmlns:its="http://www.w3.org/2005/11/its" xmlns:itsxlf="http://www.w3.org/ns/its-xliff/" its:version="3.0">
+  <file id="">
+  </file>
+</xliff>

--- a/Xliff.OM.Tests/TestData.Xliff.OM.Tests/UnitWithAttributeHavingCustomNsPrefix.xlf
+++ b/Xliff.OM.Tests/TestData.Xliff.OM.Tests/UnitWithAttributeHavingCustomNsPrefix.xlf
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<xliff srcLang="" version="2.0" xmlns="urn:oasis:names:tc:xliff:document:2.0" xmlns:custom01="urn:oasis:names:tc:xliff:sizerestriction:2.0">
+    <file id="">
+        <unit id="" custom01:storageRestriction="100" />
+    </file>
+</xliff>

--- a/Xliff.OM.Tests/Xliff.OM.Tests.csproj
+++ b/Xliff.OM.Tests/Xliff.OM.Tests.csproj
@@ -978,6 +978,9 @@
     <None Include="TestData.Xliff.OM.Tests\DocumentWithExtensions.xlf">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="TestData.Xliff.OM.Tests\DocumentWithTwoNamespaces.xlf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="TestData.Xliff.OM.Tests\DocumentWithXmlPrefix.xlf">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -1044,6 +1047,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="TestData.Xliff.OM.Tests\SpanningCodeEndWithNullId.xlf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="TestData.Xliff.OM.Tests\UnitWithAttributeHavingCustomNsPrefix.xlf">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="TestData.Xliff.OM.Tests\UnitWithMetadata.xlf">

--- a/Xliff.OM/Core/XliffElement.cs
+++ b/Xliff.OM/Core/XliffElement.cs
@@ -637,7 +637,7 @@
                                 if (key.IsInstanceOfType(ancestor))
                                 {
                                     string newProperty;
-                                    
+
                                     // Get a different property Name if specified.
                                     newProperty = inheritanceMap[key] ?? property;
 
@@ -958,9 +958,12 @@
             foreach (AttributeData attribute in this.attributes.Values)
             {
                 if (attribute.IsSupported &&
-                    (name.Prefix == attribute.Prefix) &&
+                    (name.Prefix != NamespacePrefixes.XmlNamespace) &&
                     (name.LocalName == attribute.LocalName) &&
-                    (attribute.IgnoreNamespace || (name.Namespace == attribute.Namespace)))
+                    (
+                        name.Namespace == attribute.Namespace ||
+                        attribute.IgnoreNamespace && name.Prefix == NamespacePrefixes.Xml
+                    ))
                 {
                     attribute.SetValue(value);
                     result = true;


### PR DESCRIPTION
Closes #33 

Not checking the namespace prefix name seemed to be the solution for the bug linked. 

However we also have to take care of cases where there are multiple attributes on an element with the same name (from different namespaces). See the test files from the commit:
- Xliff.OM.Tests/TestData.Xliff.OM.Tests/UnitWithAttributeHavingCustomNsPrefix.xlf (testing the issue)
- Xliff.OM.Tests/TestData.Xliff.OM.Tests/DocumentWithTwoNamespaces.xlf (testing a case with two version attributes on the xliff element; the one from the "its:" namespace should be considered an extension, while the other one should be set as a property of the corresponding XliffElement).

